### PR TITLE
Add Crime Brasil under General OSINT Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Bellingcat’s OSINT Tools](https://www.bellingcat.com/resources/) – Tools and tips used by the investigative journalism collective.
 - [IntelTechniques](https://inteltechniques.com/) – Tools and resources for private investigators and law enforcement.
 - [Maltego](https://www.maltego.com/) – Graph-based link analysis platform for intelligence and forensics.
+- [Crime Brasil](https://crimebrasil.com.br) – Brazilian crime and public-safety data platform: ~3M geocoded incidents, free REST API, CC BY 4.0. Useful for investigators working Brazilian leads.
 
 ## Search Engines & Indexes
 


### PR DESCRIPTION
Adds [Crime Brasil](https://crimebrasil.com.br) to General OSINT Resources. Open-data platform for Brazilian crime statistics — ~3M geocoded incidents from state police and federal sources, free REST API. Useful OSINT resource for investigators working Brazilian leads. CC BY 4.0. Disclosure: I'm the maintainer.