### PR TITLE
Add Xquik to social media OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Social Searcher](https://www.social-searcher.com/) – Real-time search across multiple social networks.
 - [AccountAnalysis](https://accountanalysis.app/) – Analyze public data on X/Twitter accounts.
 - [Spoonbill](https://spoonbill.io/) – Track bios and changes of Twitter profiles.
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) – X/Twitter API and MCP skill for tweet search, profile tweets, follower export, media download, monitors, and webhooks.
 - [Smihub / Dumpor (Instagram)](https://dumpor.com/) – View and download public Instagram stories and posts anonymously.
 
 ## Geolocation & Maps

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Social Searcher](https://www.social-searcher.com/) – Real-time search across multiple social networks.
 - [AccountAnalysis](https://accountanalysis.app/) – Analyze public data on X/Twitter accounts.
 - [Spoonbill](https://spoonbill.io/) – Track bios and changes of Twitter profiles.
-- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) – X/Twitter API and MCP skill for tweet search, profile tweets, follower export, media download, monitors, and webhooks.
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) – MIT-licensed X/Twitter OSINT toolkit for public tweet search, account triage, follower export, network mapping, watchlist monitors, and media preservation.
 - [Smihub / Dumpor (Instagram)](https://dumpor.com/) – View and download public Instagram stories and posts anonymously.
 
 ## Geolocation & Maps


### PR DESCRIPTION
Adds Xquik to the Social Media Investigation section as an X/Twitter API and MCP skill for tweet search, profile tweets, follower export, media download, monitors, and webhooks.

Checks performed:
- Searched the README for Xquik, x-twitter-scraper, Xquik-dev, xquik.com, xquik-docs, TweetClaw, twitterapi.io, and TwitterAPI.io.
- Searched open and closed PRs and issues for the same aliases.
- Verified the linked GitHub repository returns HTTP 200.
- Ran git diff --check.
