### PR TITLE
Add Domain Intelligence API to Domain & DNS Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [ViewDNS](https://viewdns.info/) – Tools to analyze domains, IPs, and DNS.
 - [DNSDumpster](https://dnsdumpster.com/) – Free domain research and reconnaissance tool.
 
+- [Domain Intelligence API](https://github.com/osiris-technical-institute/domain-intelligence-api) – REST API aggregating WHOIS/RDAP, DNS records, SSL certificate inspection, subdomain enumeration (CT logs + DNS bruteforce), and email security (SPF/DMARC/DKIM) for any domain in a single call. MIT-licensed, free tier available.
+
 ## IP & Network Intelligence
 
 - [IPinfo](https://ipinfo.io/) – IP address lookup and geolocation.


### PR DESCRIPTION
Adding Domain Intelligence API — REST API for domain reconnaissance. Returns WHOIS/RDAP, DNS records, SSL certificate inspection, subdomain enumeration (CT logs + DNS bruteforce across 5 sources), and email security posture (SPF/DMARC/DKIM auto-probed across 29 selectors) for any domain in a single call. MIT-licensed, free tier available. Source: https://github.com/osiris-technical-institute/domain-intelligence-api