### PR TITLE
Add GetXAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Social Searcher](https://www.social-searcher.com/) – Real-time search across multiple social networks.
 - [AccountAnalysis](https://accountanalysis.app/) – Analyze public data on X/Twitter accounts.
 - [Spoonbill](https://spoonbill.io/) – Track bios and changes of Twitter profiles.
+- [GetXAPI](https://www.getxapi.com) – Twitter/X data API for tweet search, user profiles, follower extraction, mentions, lists, and account monitoring. Public OpenAPI 3.1 spec at docs.getxapi.com/openapi.json.
 - [Smihub / Dumpor (Instagram)](https://dumpor.com/) – View and download public Instagram stories and posts anonymously.
 
 ## Geolocation & Maps


### PR DESCRIPTION
Adds GetXAPI to Social Media Investigation.

GetXAPI is a Twitter / X data API. Read endpoints (search, profiles, follower graph, mentions, lists, communities, trends) and write endpoints (post tweets, like, retweet, follow, DM, articles). Bearer-token auth. Public OpenAPI 3.1 spec.

- Site: https://www.getxapi.com
- Docs: https://docs.getxapi.com
- Spec: https://docs.getxapi.com/openapi.json
- Wikidata: https://www.wikidata.org/wiki/Q139996278

Single-line entry, factual voice matching neighboring entries (AccountAnalysis, Spoonbill, Social Searcher).