### PR TITLE
Add DNSai to Domain & DNS Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [WHOIS Lookup (ICANN)](https://lookup.icann.org/) – Official WHOIS database search.
 - [ViewDNS](https://viewdns.info/) – Tools to analyze domains, IPs, and DNS.
 - [DNSDumpster](https://dnsdumpster.com/) – Free domain research and reconnaissance tool.
+- [DNSai](https://dnsai.com/dns-tools/) – Free DNS, WHOIS, and SPF/DKIM/DMARC lookups with plain-English results and no signup.
 
 ## IP & Network Intelligence
 


### PR DESCRIPTION
### Checklist
- [x] My submission is useful and relevant to this list.
- [ ] - [x] I've added a short description for the resource.
- [ ] - [x] The link is not a duplicate.
- [ ] - [x] The link is working and publicly accessible.
- [ ] - [x] I've checked that the resource follows the quality and content standards.
### Description of the Change
Adds DNSai to the Domain & DNS Tools section, alongside ViewDNS and DNSDumpster. DNSai offers free DNS, WHOIS, and SPF/DKIM/DMARC lookups with plain-English results and no signup.

### Additional Notes
Disclosure: I'm affiliated with DNSai. Happy to adjust the wording or remove it if it doesn't meet the notability bar.