### PR TITLE
Add SiteData to Domain & DNS Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [WHOIS Lookup (ICANN)](https://lookup.icann.org/) – Official WHOIS database search.
 - [ViewDNS](https://viewdns.info/) – Tools to analyze domains, IPs, and DNS.
 - [DNSDumpster](https://dnsdumpster.com/) – Free domain research and reconnaissance tool.
+- [SiteData](https://sitedata.dev/) — Website investigation tool for mapping related domains through shared AdSense publisher IDs and Google Ads advertisers, with WHOIS, traffic, and SEO context.
 
 ## IP & Network Intelligence
 


### PR DESCRIPTION
## Thank you for your contribution!

Please make sure your pull request follows our guidelines:

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [x] I have not added a link to my own project if it's not notable or widely used.

### Description of the Change

Adds SiteData to the **Domain & DNS Tools** section.

SiteData supports public website investigation workflows that begin with a domain, AdSense publisher ID, or Google Ads advertiser. Investigators can pivot between related domains and use WHOIS, traffic, SEO, and advertising signals as supporting context.

Its distinction from general DNS or WHOIS lookup tools is the ability to map website relationships through shared monetization and advertiser identifiers.

### Additional Notes

Disclosure: I am affiliated with SiteData.

Public maturity evidence: the [SiteData Chrome extension](https://chromewebstore.google.com/detail/sitedata-traffic-checkera/emeakbgdecgmdjgegnejpppcnkcnoaen) is Featured and, as checked on August 15, 2026, lists 7,000 users with a 4.9/5 rating from 61 ratings.

This PR follows the maintainer guidance in #31 to use the contribution process instead of an issue-based resource request.

Validation performed:

- Confirmed `https://sitedata.dev/` returns HTTP 200.
- Confirmed the resource is not already listed in `README.md` and has no existing pull request.
- Confirmed the duplicate-link check passes. The awesome-list lint reproduces 42 pre-existing failures on the unmodified `main` branch due to a dash-character mismatch; this entry uses the accepted format and does not add a new lint failure.
- Ran `git diff --check`.
