### PR TITLE
Add MyIPScan to IP & Network Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [IPinfo](https://ipinfo.io/) – IP address lookup and geolocation.
 - [SecurityTrails](https://securitytrails.com/) – Domain, IP, and DNS information.
 - [AbuseIPDB](https://www.abuseipdb.com/) – Check if an IP has been reported for abuse.
+- [MyIPScan](https://myipscan.net/tools/) – Browser-based IP, ASN, WHOIS/RDAP, reverse DNS and IP-range lookups, plus DNS, WebRTC and IPv6 leak tests.
 
 ## Dark Web OSINT
 


### PR DESCRIPTION
Adding MyIPScan to IP & Network Intelligence, alongside IPinfo and SecurityTrails. Browser-based, free, no account: IP and ASN lookup, WHOIS/RDAP, reverse DNS, IP ranges by provider, and DNS/WebRTC/IPv6 leak tests.

Followed CONTRIBUTING.md for formatting and category placement. Disclosure: I maintain this site — happy for you to close this if it is out of scope.

## Thank you for your contribution!

Please make sure your pull request follows our guidelines:

### Checklist

- [ ] My submission is useful and relevant to this list.
- [ ] I've added a short description for the resource.
- [ ] The link is not a duplicate.
- [ ] The link is working and publicly accessible.
- [ ] I've checked that the resource follows our quality and content standards.
- [ ] I have not added a link to my own project if it's not notable or widely used.

### Description of the Change

<!-- Describe why you are adding this resource and why it's Awesome -->

### Additional Notes (if any)

<!-- Optional: Any notes for reviewers -->
